### PR TITLE
見た目の変更

### DIFF
--- a/lib/infrastructure/db/init/sample_data.dart
+++ b/lib/infrastructure/db/init/sample_data.dart
@@ -41,7 +41,7 @@ const _sampleDataScripts = [
     INSERT INTO scenes_phrases(scene_id, phrase_id) VALUES(3, 4);
   ''',
   '''
-    INSERT INTO reasons(reason, is_default) VALUES('喉が痛いのでこちらで注文します', 1);
+    INSERT INTO reasons(reason, is_default) VALUES('話すことが苦手なのでこちらで注文します', 1);
   ''',
   '''
     INSERT INTO payment_methods(method, is_default) VALUES('PayPay', 1);

--- a/lib/ui/component/app_bar/simple_bottom_app_bar.dart
+++ b/lib/ui/component/app_bar/simple_bottom_app_bar.dart
@@ -38,7 +38,7 @@ class SimpleBottomAppBar extends StatelessWidget {
             _buildBottomAppBarItem(
               context: context,
               icon: Icons.settings,
-              label: '管理メニュー',
+              label: 'メニュー',
               onPressed: () => Navigator.pushAndRemoveUntil(
                 context,
                 MaterialPageRoute(builder: (context) => const ManagementPage()),

--- a/lib/ui/component/form/simple_checkbox_list_tile.dart
+++ b/lib/ui/component/form/simple_checkbox_list_tile.dart
@@ -21,7 +21,12 @@ class SimpleCheckboxListTile extends StatelessWidget {
     return CheckboxListTile(
         value: value,
         onChanged: onChanged,
-        title: Text(title),
+        title: Text(
+          title,
+          style: TextStyle(
+            fontSize: 16 * MediaQuery.of(context).textScaleFactor,
+          ),
+        ),
         tileColor: tileColor ?? Theme.of(context).colorScheme.surface,
         dense: dense);
   }

--- a/lib/ui/component/no_registered_data.dart
+++ b/lib/ui/component/no_registered_data.dart
@@ -1,32 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:more_order_app/ui/component/button/navigation_button.dart';
 
 class NoRegisteredData extends StatelessWidget {
   final String message;
-  final NavigationButton? navigationButton;
 
   const NoRegisteredData({
     Key? key,
     required this.message,
-    this.navigationButton,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    List<Widget> children = [
-      Text(message),
-      const SizedBox(height: 16),
-    ];
-
-    if (navigationButton != null) {
-      children.add(navigationButton!);
-    }
-
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        children: children,
-      ),
-    );
+    return Container(alignment: Alignment.topLeft, child: Text(message));
   }
 }

--- a/lib/ui/component/snack_bar/simple_snackbar.dart
+++ b/lib/ui/component/snack_bar/simple_snackbar.dart
@@ -21,7 +21,7 @@ class SimpleSnackBar extends SnackBar {
             ],
           ),
           backgroundColor:
-              type == SnackBarType.success ? Colors.brown : Colors.red,
+              type == SnackBarType.success ? Colors.green : Colors.red,
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(8.0),

--- a/lib/ui/component/typography/section_title.dart
+++ b/lib/ui/component/typography/section_title.dart
@@ -2,19 +2,27 @@ import 'package:flutter/material.dart';
 
 class SectionTitle extends StatelessWidget {
   final String text;
-  const SectionTitle({Key? key, required this.text}) : super(key: key);
+  final Widget? rightContent;
+  const SectionTitle({Key? key, required this.text, this.rightContent})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.only(bottom: 12.0),
-      child: Text(
-        text,
-        style: TextStyle(
-          fontSize: 16 * MediaQuery.of(context).textScaleFactor,
-          color: Theme.of(context).colorScheme.primary,
-          fontWeight: FontWeight.bold,
-        ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            text,
+            style: TextStyle(
+              fontSize: 16 * MediaQuery.of(context).textScaleFactor,
+              color: Theme.of(context).colorScheme.primary,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          if (rightContent != null) rightContent!,
+        ],
       ),
     );
   }

--- a/lib/ui/page/management/page.dart
+++ b/lib/ui/page/management/page.dart
@@ -18,7 +18,7 @@ class ManagementPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultLayout(
-      title: "管理メニュー",
+      title: "メニュー",
       body: ListView(
         children: [
           MenuItem(title: "フレーズ", options: [

--- a/lib/ui/page/management/reason/component/reason_input_form.dart
+++ b/lib/ui/page/management/reason/component/reason_input_form.dart
@@ -30,7 +30,7 @@ class ReasonInputField extends StatelessWidget {
           controller: controller,
           initialValue: initialValue,
           decoration: const InputDecoration(
-            hintText: '例: 喉が痛いのでこちらで注文します',
+            hintText: '例: 話すことが苦手なのでこちらで注文します',
           ),
           onChanged: onChanged,
         ),

--- a/lib/ui/page/order/display/component/phrases.dart
+++ b/lib/ui/page/order/display/component/phrases.dart
@@ -3,25 +3,38 @@ import 'package:more_order_app/domain/entity/phrase.dart';
 
 class Phrases extends StatelessWidget {
   final List<Phrase> phrases;
+
   const Phrases({Key? key, required this.phrases}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Column(
-      children: phrases
-          .map(
-            (phrase) => ListTile(
-              leading: const Icon(Icons.fiber_manual_record),
-              title: Text(
-                phrase.phrase,
-                style: TextStyle(
-                  fontSize: 24 * MediaQuery.of(context).textScaleFactor,
+      children: phrases.map((phrase) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                // アイコンとテキストがずれるので調整
+                padding: EdgeInsets.only(
+                    top: 6.0 * MediaQuery.of(context).textScaleFactor),
+                child: Icon(Icons.fiber_manual_record,
+                    size: 16 * MediaQuery.of(context).textScaleFactor),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  phrase.phrase,
+                  style: TextStyle(
+                    fontSize: 24 * MediaQuery.of(context).textScaleFactor,
+                  ),
                 ),
               ),
-              contentPadding: EdgeInsets.zero,
-            ),
-          )
-          .toList(),
+            ],
+          ),
+        );
+      }).toList(),
     );
   }
 }

--- a/lib/ui/page/order/select/component/no_payment_method.dart
+++ b/lib/ui/page/order/select/component/no_payment_method.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:more_order_app/ui/component/button/navigation_button.dart';
 import 'package:more_order_app/ui/component/no_registered_data.dart';
-import 'package:more_order_app/ui/page/management/payment_method/add/page.dart';
 
 class NoPaymentMethod extends StatelessWidget {
   const NoPaymentMethod({Key? key}) : super(key: key);
@@ -9,12 +7,9 @@ class NoPaymentMethod extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const NoRegisteredData(
-      message: "支払方法が登録されていません",
-      navigationButton: NavigationButton(
-        nextPage: PaymentMethodAddPage(),
-        text: "支払方法を登録",
-        isSecondary: true,
-      ),
+      message: '''注文時に「PayPay」、「現金」などの支払方法を表示することができます。
+非表示にすることもできるので、何かしら登録してみることをおすすめします。
+''',
     );
   }
 }

--- a/lib/ui/page/order/select/component/no_phrase.dart
+++ b/lib/ui/page/order/select/component/no_phrase.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:more_order_app/ui/component/button/navigation_button.dart';
 import 'package:more_order_app/ui/component/no_registered_data.dart';
-import 'package:more_order_app/ui/page/management/phrase/add/page.dart';
 
 class NoPhrase extends StatelessWidget {
   const NoPhrase({Key? key}) : super(key: key);
@@ -9,12 +7,7 @@ class NoPhrase extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const NoRegisteredData(
-      message: "フレーズが登録されていません",
-      navigationButton: NavigationButton(
-        nextPage: PhraseAddPage(),
-        text: "フレーズを登録",
-        isSecondary: true,
-      ),
+      message: '''「カフェラテ」、「お弁当の温め」など、注文したいフレーズを登録しましょう。''',
     );
   }
 }

--- a/lib/ui/page/order/select/component/no_reason.dart
+++ b/lib/ui/page/order/select/component/no_reason.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:more_order_app/ui/component/button/navigation_button.dart';
 import 'package:more_order_app/ui/component/no_registered_data.dart';
-import 'package:more_order_app/ui/page/management/reason/add/page.dart';
 
 class NoReason extends StatelessWidget {
   const NoReason({Key? key}) : super(key: key);
@@ -9,12 +7,9 @@ class NoReason extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const NoRegisteredData(
-      message: "理由が登録されていません",
-      navigationButton: NavigationButton(
-        nextPage: ReasonAddPage(),
-        text: "理由を登録",
-        isSecondary: true,
-      ),
+      message: '''注文時に「喉が痛いのでこちらで注文します」、「話すことが苦手なのでこちらで注文します」などの理由を表示することができます。
+非表示にすることもできるので、何かしら登録してみることをおすすめします。
+''',
     );
   }
 }

--- a/lib/ui/page/order/select/page.dart
+++ b/lib/ui/page/order/select/page.dart
@@ -50,11 +50,11 @@ class OrderSelectPage extends ConsumerWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const SectionTitle(
+                              SectionTitle(
                                 text: "理由",
                                 rightContent: TextLinkButton(
-                                  nextPage: ReasonAddPage(),
-                                  text: '理由の追加',
+                                  nextPage: const ReasonAddPage(),
+                                  text: reasons.isEmpty ? '理由の登録' : '理由の追加',
                                 ),
                               ),
                               reasons.isEmpty
@@ -80,11 +80,11 @@ class OrderSelectPage extends ConsumerWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const SectionTitle(
+                              SectionTitle(
                                 text: "フレーズ",
                                 rightContent: TextLinkButton(
-                                  nextPage: PhraseAddPage(),
-                                  text: 'フレーズの追加',
+                                  nextPage: const PhraseAddPage(),
+                                  text: reasons.isEmpty ? 'フレーズの登録' : 'フレーズの追加',
                                 ),
                               ),
                               if (scene.phrases.isEmpty) const NoPhrase(),
@@ -108,11 +108,11 @@ class OrderSelectPage extends ConsumerWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const SectionTitle(
+                              SectionTitle(
                                 text: "支払方法",
                                 rightContent: TextLinkButton(
-                                  nextPage: ReasonAddPage(),
-                                  text: '支払方法の追加',
+                                  nextPage: const ReasonAddPage(),
+                                  text: reasons.isEmpty ? '支払方法の登録' : '支払方法の追加',
                                 ),
                               ),
                               paymentMethods.isEmpty

--- a/lib/ui/page/order/select/page.dart
+++ b/lib/ui/page/order/select/page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:more_order_app/domain/valueObject/id.dart';
 import 'package:more_order_app/ui/component/button/navigation_button.dart';
+import 'package:more_order_app/ui/component/button/text_link_button.dart';
 import 'package:more_order_app/ui/component/error_message.dart';
 import 'package:more_order_app/ui/component/form/simple_checkbox_list_tile.dart';
 import 'package:more_order_app/ui/component/form/simple_select_form.dart';
@@ -10,6 +11,8 @@ import 'package:more_order_app/ui/component/loader.dart';
 import 'package:more_order_app/ui/component/typography/section_title.dart';
 import 'package:more_order_app/ui/form/form_creation_status.dart';
 import 'package:more_order_app/ui/layout/default_layout.dart';
+import 'package:more_order_app/ui/page/management/phrase/add/page.dart';
+import 'package:more_order_app/ui/page/management/reason/add/page.dart';
 import 'package:more_order_app/ui/page/order/display/page.dart';
 import 'package:more_order_app/ui/page/order/select/component/no_payment_method.dart';
 import 'package:more_order_app/ui/page/order/select/component/no_phrase.dart';
@@ -47,7 +50,13 @@ class OrderSelectPage extends ConsumerWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const SectionTitle(text: "理由"),
+                              const SectionTitle(
+                                text: "理由",
+                                rightContent: TextLinkButton(
+                                  nextPage: ReasonAddPage(),
+                                  text: '理由の追加',
+                                ),
+                              ),
                               reasons.isEmpty
                                   ? const NoReason()
                                   : SimpleSelectForm(
@@ -71,7 +80,13 @@ class OrderSelectPage extends ConsumerWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const SectionTitle(text: "フレーズ"),
+                              const SectionTitle(
+                                text: "フレーズ",
+                                rightContent: TextLinkButton(
+                                  nextPage: PhraseAddPage(),
+                                  text: 'フレーズの追加',
+                                ),
+                              ),
                               if (scene.phrases.isEmpty) const NoPhrase(),
                               ...scene.phrases.map(
                                 (phrase) {
@@ -93,7 +108,13 @@ class OrderSelectPage extends ConsumerWidget {
                           Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const SectionTitle(text: "支払方法"),
+                              const SectionTitle(
+                                text: "支払方法",
+                                rightContent: TextLinkButton(
+                                  nextPage: ReasonAddPage(),
+                                  text: '支払方法の追加',
+                                ),
+                              ),
                               paymentMethods.isEmpty
                                   ? const NoPaymentMethod()
                                   : SimpleSelectForm(

--- a/lib/ui/page/tutorial/page.dart
+++ b/lib/ui/page/tutorial/page.dart
@@ -28,7 +28,7 @@ class TutorialPageState extends State<TutorialPage>
       PageModel.withChild(
         color: Theme.of(context).colorScheme.onPrimary,
         child: const PageModelChild(
-          title: '生活するとは"注文する"こと',
+          title: '生活するとは\n"注文する"こと',
           imageAssetPath: "assets/images/tutorial/ordinary_order.png",
           body: '''
 からあげ棒下さい。
@@ -46,7 +46,7 @@ PayPayで払います。
           title: '注文したいけど注文できない',
           imageAssetPath: "assets/images/tutorial/cannot_speak.png",
           body: '''
-吃音症、場面緘黙症、人見知り、難聴。
+人見知り、吃音症、場面緘黙症、難聴。
 
 様々な理由で、
 私たちは注文したくてもできません。
@@ -74,14 +74,14 @@ PayPayで払います。
       PageModel.withChild(
         color: Theme.of(context).colorScheme.onPrimary,
         child: const PageModelChild(
-          title: "さあ、今こそ世の中の便利を享受しよう！",
+          title: "さあ、今こそ世の中の便利を体感しよう！",
           imageAssetPath: "assets/images/tutorial/more_order.png",
           body: '''
 諦めるのは今ここで最後にしましょう。
 "More Order"を使えば、
 私たちの好きなものが注文できます。
 
-さあ、今こそ世の中の便利を享受しよう！
+さあ、今こそ世の中の便利を体感しよう！
 ''',
         ),
       ),


### PR DESCRIPTION
## issueへのリンク（あれば）

## 目的（実現したいこと）
使いやすくする

## やったこと
- 成功時のスナックバーの色がエラー時の色と紛らわしいので、緑にする
- 注文画面でフレーズを箇条書きで表示するときの、箇条書きの黒ポチの位置を文字と揃える（`CrossAxisAlignment.center -> CrossAxisAlignment.top`みたいなことをした）
- データ未登録時の見た目を変えた

## 動作確認

## 補足
